### PR TITLE
tk.Scale resolution fix, python warnings fixes

### DIFF
--- a/WowFile/tkViewer.py
+++ b/WowFile/tkViewer.py
@@ -49,7 +49,7 @@ class WOWFileViewer:
         tickinterval = self.layer_count/10
         self.layer_select = tk.Scale(master, from_=1, to=self.layer_count,
                                      command=self.sliderUpdate, orient=tk.VERTICAL,
-                                     resolution=-1, length=400, tickinterval=tickinterval,
+                                     resolution=1, length=400, tickinterval=tickinterval,
                                      takefocus=1)
         self.layer_select.grid(row=2, column=8, sticky=tk.E+tk.W+tk.N+tk.S)
 
@@ -232,7 +232,7 @@ def main():
     lbl = tk.Label(root, text="Please Wait...")
     lbl.grid(row=1, column=1)
     filename = tkinter.filedialog.askopenfilename(filetypes=(("WOW print file", "*.wow"),("All files", "*.*")))
-    if filename is "":
+    if filename == "":
         sys.exit(0)
 
     lbl.configure(text="")

--- a/WowFile/wow.py
+++ b/WowFile/wow.py
@@ -80,7 +80,7 @@ def _g1(code, cur_layer):
 
                 cur_layer.thickness += distance
                 cur_layer.thickness = round(cur_layer.thickness, 5)
-                if speed is not 0:
+                if speed != 0:
                     cur_layer.move_time += abs(distance) / (speed / 60)
                     if distance > 0:
                         cur_layer.speed_up = speed
@@ -89,7 +89,7 @@ def _g1(code, cur_layer):
 
         elif param[0] == "F" or param[0] == "f":
             speed = float(param[1:])
-            if distance is not 0:
+            if distance != 0:
                 cur_layer.move_time += abs(distance) / (speed / 60)
                 if distance > 0:
                     cur_layer.speed_up = speed


### PR DESCRIPTION
Warnings
```
WoWTools/WowFile/wow.py:83: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if speed is not 0:
WoWTools/WowFile/wow.py:92: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if distance is not 0:
WoWTools/WowFile/tkViewer.py:235: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if filename is "":
```

tk.Scale Error
```
Exception in Tkinter callback
Traceback (most recent call last):
  File "python/3.10.12/lib/python3.10/tkinter/__init__.py", line 1921, in __call__
    return self.func(*args)
  File "WoWTools/WowFile/tkViewer.py", line 209, in sliderUpdate
    self.layerChange(int(pos))
ValueError: invalid literal for int() with base 10: '1.2'
```